### PR TITLE
Create AWS OIDC Role for Terraform

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,4 @@
-provider "aws" {
-  region = "us-east-1"
-}
+
 
 resource "aws_iam_openid_connect_provider" "this" {
   url = "https://token.actions.githubusercontent.com"

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,58 @@
+resource "aws_iam_openid_connect_provider" "this" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  thumbprint_list = ["ffffffffffffffffffffffffffffffffffffffff"]
+}
+
+data "aws_iam_policy_document" "oidc" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.this.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["sts.amazonaws.com"]
+      variable = "token.actions.githubusercontent.com:aud"
+    }
+
+    condition {
+      test     = "StringLike"
+      values   = ["repo:YourOrg/*"]
+      variable = "token.actions.githubusercontent.com:sub"
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name               = "github_oidc_role"
+  assume_role_policy = data.aws_iam_policy_document.oidc.json
+}
+
+data "aws_iam_policy_document" "deploy" {
+  statement {
+    effect  = "Allow"
+    actions = [
+      "ecr:*",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "deploy" {
+  name        = "ci-deploy-policy"
+  description = "Policy used for deployments on CI"
+  policy      = data.aws_iam_policy_document.deploy.json
+}
+
+resource "aws_iam_role_policy_attachment" "attach-deploy" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.deploy.arn
+}

--- a/iam.tf
+++ b/iam.tf
@@ -5,7 +5,6 @@ resource "aws_iam_openid_connect_provider" "this" {
     "sts.amazonaws.com",
   ]
 
-  thumbprint_list = ["ffffffffffffffffffffffffffffffffffffffff"]
 }
 
 data "aws_iam_policy_document" "oidc" {
@@ -25,7 +24,7 @@ data "aws_iam_policy_document" "oidc" {
 
     condition {
       test     = "StringLike"
-      values   = ["repo:YourOrg/*"]
+      values   = ["repo:awscommunitymx"]
       variable = "token.actions.githubusercontent.com:sub"
     }
   }
@@ -43,6 +42,8 @@ data "aws_iam_policy_document" "deploy" {
       "ecr:*",
     ]
     resources = ["*"]
+    
+    
   }
 }
 
@@ -56,3 +57,27 @@ resource "aws_iam_role_policy_attachment" "attach-deploy" {
   role       = aws_iam_role.this.name
   policy_arn = aws_iam_policy.deploy.arn
 }
+
+data "aws_iam_policy_document" "cdk" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    resources = [
+      "arn:aws:iam::*:role/cdk-*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "cdk" {
+  name        = "cdk-policy"
+  description = "Policy used for CDK deployments"
+  policy      = data.aws_iam_policy_document.cdk.json
+}
+
+resource "aws_iam_role_policy_attachment" "attach-cdk" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.cdk.arn
+}
+

--- a/iam.tf
+++ b/iam.tf
@@ -35,29 +35,6 @@ resource "aws_iam_role" "this" {
   assume_role_policy = data.aws_iam_policy_document.oidc.json
 }
 
-data "aws_iam_policy_document" "deploy" {
-  statement {
-    effect  = "Allow"
-    actions = [
-      "ecr:*",
-    ]
-    resources = ["*"]
-    
-    
-  }
-}
-
-resource "aws_iam_policy" "deploy" {
-  name        = "ci-deploy-policy"
-  description = "Policy used for deployments on CI"
-  policy      = data.aws_iam_policy_document.deploy.json
-}
-
-resource "aws_iam_role_policy_attachment" "attach-deploy" {
-  role       = aws_iam_role.this.name
-  policy_arn = aws_iam_policy.deploy.arn
-}
-
 data "aws_iam_policy_document" "cdk" {
   statement {
     effect = "Allow"

--- a/iam.tf
+++ b/iam.tf
@@ -1,11 +1,16 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
 resource "aws_iam_openid_connect_provider" "this" {
   url = "https://token.actions.githubusercontent.com"
 
   client_id_list = [
     "sts.amazonaws.com",
   ]
-
 }
+
+data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "oidc" {
   statement {
@@ -24,7 +29,7 @@ data "aws_iam_policy_document" "oidc" {
 
     condition {
       test     = "StringLike"
-      values   = ["repo:awscommunitymx"]
+      values   = ["repo:awscommunitymx/*"]
       variable = "token.actions.githubusercontent.com:sub"
     }
   }
@@ -42,7 +47,7 @@ data "aws_iam_policy_document" "cdk" {
       "sts:AssumeRole",
     ]
     resources = [
-      "arn:aws:iam::*:role/cdk-*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/cdk-*",
     ]
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}


### PR DESCRIPTION
Closes #3

## Summary by Sourcery

Creates an AWS IAM OIDC role and policy for use with GitHub Actions and CDK deployments. This allows GitHub Actions to assume a role in AWS using OIDC, and grants the role permissions to assume CDK deployment roles.