### PR TITLE
Add default tags to AWS provider configuration

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,9 @@
 provider "aws" {
   region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Terraform = "true"
+    }
+  }
 }


### PR DESCRIPTION
Close #7

## Summary by Sourcery

Enhancements:
- Adds a default tag to the AWS provider configuration to tag all resources created by Terraform.