### PR TITLE
Migrate AWS account

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "org-terraform-state-environment"
+    bucket         = "org-terraform-state-environment-app"
     key            = "terraform.tfstate"
     region         = "us-east-1"
     encrypt        = true

--- a/iam.tf
+++ b/iam.tf
@@ -43,6 +43,7 @@ data "aws_iam_policy_document" "cdk" {
     effect = "Allow"
     actions = [
       "sts:AssumeRole",
+      "s3:GetObject" 
     ]
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/cdk-*",
@@ -61,12 +62,23 @@ resource "aws_iam_role_policy_attachment" "attach-cdk" {
   policy_arn = aws_iam_policy.cdk.arn
 }
 resource "aws_iam_role_policy_attachment" "appsync_admin_attachment" {
-  role       = "github_oidc_role"
+  role       =  aws_iam_role.this.name
+
   policy_arn = "arn:aws:iam::aws:policy/AWSAppSyncAdministrator"
 }
 
 resource "aws_iam_role_policy_attachment" "cloudformation_full_access_attachment" {
-  role       = "github_oidc_role"
+  role       =  aws_iam_role.this.name
   policy_arn = "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
 }
 
+resource "aws_iam_role_policy_attachment" "Lambda_Full_Access_attachment" {
+  role       =  aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
+}
+
+
+resource "aws_iam_role_policy_attachment" "AmazonS3FullAccess_attachment" {
+  role       =  aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}

--- a/iam.tf
+++ b/iam.tf
@@ -60,4 +60,13 @@ resource "aws_iam_role_policy_attachment" "attach-cdk" {
   role       = aws_iam_role.this.name
   policy_arn = aws_iam_policy.cdk.arn
 }
+resource "aws_iam_role_policy_attachment" "appsync_admin_attachment" {
+  role       = "github_oidc_role"
+  policy_arn = "arn:aws:iam::aws:policy/AWSAppSyncAdministrator"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudformation_full_access_attachment" {
+  role       = "github_oidc_role"
+  policy_arn = "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
+}
 


### PR DESCRIPTION
## Summary by Sourcery

Migrate AWS account configuration by updating IAM roles and Terraform backend settings

New Features:
- Add policy attachments for AppSync, CloudFormation, Lambda, and S3 full access

Enhancements:
- Expand IAM role permissions to include additional AWS service access

Deployment:
- Update Terraform backend S3 bucket to a new environment-specific bucket