### PR TITLE
Add Cloudflare provider and Route53 zone configuration

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,6 +1,21 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.2.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:JC86gRl0Hbavb0PTSI7z6K/h/BD5SYg14fyCVRu3Tp8=",
+    "zh:1c2785da1d01b2afd0cca625e8fee472a36f681dc206823db9d59e82a4a7db68",
+    "zh:cfe874ddc069cce594f2b660bbac4692bf267012002e1884fd0772ba3ddd77ef",
+    "zh:debe086c0fee03bebebce9bf387ff3859efb54471d10981fe408de81c1af03f1",
+    "zh:e42fa5538a90620a366af7a32a48197fcb4509c6ade5ad4750166435de06fbe3",
+    "zh:e8d6eef684bbd12c6d9678a8ebeb7be982eb44f5916e1c471419dd78d3911848",
+    "zh:ea0698597ccc8a5fef56d0b76678a20701dc4f8b74e4b4c53904e3372cb50de7",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version = "5.90.0"
   hashes = [

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   version     = "5.2.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:5jsxVZa5nYIKUB+JjLbk+2x6az6XRmBg6mSql6aTP3U=",
     "h1:JC86gRl0Hbavb0PTSI7z6K/h/BD5SYg14fyCVRu3Tp8=",
     "zh:1c2785da1d01b2afd0cca625e8fee472a36f681dc206823db9d59e82a4a7db68",
     "zh:cfe874ddc069cce594f2b660bbac4692bf267012002e1884fd0772ba3ddd77ef",
@@ -20,6 +21,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "5.90.0"
   hashes = [
     "h1:ZXV8UApQVdwv26/KDJjcRThhZRsHakOfxzsix5w8L64=",
+    "h1:cJ3ab7uBP0NmD+LzxHK63ZG1o9nIppAjt6c0OafGKPw=",
     "zh:0ed246595c4ffb3ea3649528ff171503db208fb20be5f750b8e359d17ee72b60",
     "zh:1d5c500913b5df0fbf5e8143354aecc736cc4e66d58d4ab17deb24b721ab743a",
     "zh:337f3511335e6e32431548913d1973ae077d1a4c2f77677675c92c60cd2f5e0a",

--- a/backend.tf
+++ b/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "org-terraform-state-environment"
+    bucket         = "org-terraform-state-environment-app"
     key            = "terraform.tfstate"
     region         = "us-east-1"
     encrypt        = true

--- a/backend.tf
+++ b/backend.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "org-terraform-state-environment-app"
-    key            = "terraform.tfstate"
-    region         = "us-east-1"
-    encrypt        = true
-    use_lockfile   = true 
+    bucket       = "org-terraform-state-environment-app"
+    key          = "terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+    use_lockfile = true
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -59,28 +59,28 @@ resource "aws_iam_role_policy_attachment" "attach-cdk" {
   policy_arn = aws_iam_policy.cdk.arn
 }
 resource "aws_iam_role_policy_attachment" "appsync_admin_attachment" {
-  role       =  aws_iam_role.this.name
+  role       = aws_iam_role.this.name
   policy_arn = "arn:aws:iam::aws:policy/AWSAppSyncAdministrator"
 }
 
 resource "aws_iam_role_policy_attachment" "cloudformation_full_access_attachment" {
-  role       =  aws_iam_role.this.name
+  role       = aws_iam_role.this.name
   policy_arn = "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "Lambda_Full_Access_attachment" {
-  role       =  aws_iam_role.this.name
+  role       = aws_iam_role.this.name
   policy_arn = "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "AmazonS3FullAccess_attachment" {
-  role       =  aws_iam_role.this.name
+  role       = aws_iam_role.this.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 resource "aws_iam_policy" "dynamodb_full_access" {
   name        = "dynamodb-full-access-policy"
   description = "Policy for full access to DynamoDB"
-  policy      = jsonencode({
+  policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {

--- a/iam.tf
+++ b/iam.tf
@@ -41,7 +41,6 @@ data "aws_iam_policy_document" "cdk" {
     effect = "Allow"
     actions = [
       "sts:AssumeRole",
-      "s3:GetObject" 
     ]
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/cdk-*",
@@ -61,7 +60,6 @@ resource "aws_iam_role_policy_attachment" "attach-cdk" {
 }
 resource "aws_iam_role_policy_attachment" "appsync_admin_attachment" {
   role       =  aws_iam_role.this.name
-
   policy_arn = "arn:aws:iam::aws:policy/AWSAppSyncAdministrator"
 }
 
@@ -97,24 +95,4 @@ resource "aws_iam_policy" "dynamodb_full_access" {
 resource "aws_iam_role_policy_attachment" "dynamodb_full_access_attachment" {
   role       = aws_iam_role.this.name
   policy_arn = aws_iam_policy.dynamodb_full_access.arn
-}
-
-resource "aws_iam_role_policy_attachment" "appsync_admin_attachment" {
-  role       = aws_iam_role.this.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSAppSyncAdministrator"
-}
-
-resource "aws_iam_role_policy_attachment" "cloudformation_full_access_attachment" {
-  role       =  aws_iam_role.this.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "Lambda_Full_Access_attachment" {
-  role       =  aws_iam_role.this.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "AmazonS3FullAccess_attachment" {
-  role       =  aws_iam_role.this.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -7,3 +7,17 @@ provider "aws" {
     }
   }
 }
+
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = ""
+}
+

--- a/providers.tf
+++ b/providers.tf
@@ -17,7 +17,4 @@ terraform {
   }
 }
 
-provider "cloudflare" {
-  api_token = ""
-}
-
+provider "cloudflare" {}

--- a/providers.tf
+++ b/providers.tf
@@ -17,4 +17,6 @@ terraform {
   }
 }
 
-provider "cloudflare" {}
+provider "cloudflare" {
+  api_token = var.cloudflare_api_key
+}

--- a/route53.tf
+++ b/route53.tf
@@ -1,0 +1,33 @@
+resource "aws_route53_zone" "dev" {
+  name = "app.awscommunity.mx"
+
+  tags = {
+    Environment = "app"
+  }
+}
+
+data "cloudflare_zone" "main_zone" {
+  zone_id = ""
+}
+
+
+# Outputs
+output "app_zone_id" {
+  description = "ID de la zona alojada de Route53"
+  value       = aws_route53_zone.dev.zone_id
+}
+
+output "app_zone_name_servers" {
+  description = "Servidores de nombres asignados a la zona alojada"
+  value       = aws_route53_zone.dev.name_servers
+}
+# 3. Update Cloudflare NS Records
+resource "cloudflare_dns_record" "ns" {
+  for_each = toset(aws_route53_zone.dev.name_servers) # Convierte la lista en un conjunto para iterar
+  zone_id = data.cloudflare_zone.main_zone.zone_id
+  name    = "app.awscommunity.mx" # Nombre de la zona en Cloudflare
+  type    = "NS"
+  ttl     = 1 
+  content = each.value
+}
+

--- a/route53.tf
+++ b/route53.tf
@@ -7,21 +7,9 @@ resource "aws_route53_zone" "dev" {
 }
 
 data "cloudflare_zone" "main_zone" {
-  zone_id = ""
+  zone_id = "914f895b638c5fd3731948303b6d0b26"
 }
 
-
-# Outputs
-output "app_zone_id" {
-  description = "ID de la zona alojada de Route53"
-  value       = aws_route53_zone.dev.zone_id
-}
-
-output "app_zone_name_servers" {
-  description = "Servidores de nombres asignados a la zona alojada"
-  value       = aws_route53_zone.dev.name_servers
-}
-# 3. Update Cloudflare NS Records
 resource "cloudflare_dns_record" "ns" {
   for_each = toset(aws_route53_zone.dev.name_servers) # Convierte la lista en un conjunto para iterar
   zone_id = data.cloudflare_zone.main_zone.zone_id

--- a/route53.tf
+++ b/route53.tf
@@ -12,10 +12,10 @@ data "cloudflare_zone" "main_zone" {
 
 resource "cloudflare_dns_record" "ns" {
   for_each = toset(aws_route53_zone.dev.name_servers) # Convierte la lista en un conjunto para iterar
-  zone_id = data.cloudflare_zone.main_zone.zone_id
-  name    = "app.awscommunity.mx" # Nombre de la zona en Cloudflare
-  type    = "NS"
-  ttl     = 1 
-  content = each.value
+  zone_id  = data.cloudflare_zone.main_zone.zone_id
+  name     = "app.awscommunity.mx" # Nombre de la zona en Cloudflare
+  type     = "NS"
+  ttl      = 1
+  content  = each.value
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,1 @@
+variable "cloudflare_api_key" {}

--- a/variables.tf
+++ b/variables.tf
@@ -1,1 +1,5 @@
-variable "cloudflare_api_key" {}
+variable "cloudflare_api_key" {
+  description = "Cloudflare API token"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
Closes #11

## Summary by Sourcery

Configure Cloudflare and Route53 DNS infrastructure for a new application environment

New Features:
- Create a new Route53 hosted zone for 'app.awscommunity.mx'
- Add Cloudflare DNS provider configuration
- Set up Cloudflare NS records for the new Route53 zone

Enhancements:
- Update Terraform backend configuration to use a more specific S3 bucket name

Chores:
- Add Cloudflare provider to Terraform configuration
- Create outputs for Route53 zone details