### PR TITLE
Add ACM certificate and Route53 DNS validation configuration

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -1,0 +1,31 @@
+resource "aws_acm_certificate" "awscommunity_certificate" {
+  domain_name       = "*.app.awscommunity.mx"
+  validation_method = "DNS"
+}
+
+data "aws_route53_zone" "awscommunity_zone" {
+  name         = "app.awscommunity.mx"
+  private_zone = false
+}
+
+resource "aws_route53_record" "awscommunity_validation_record" {
+  for_each = {
+    for dvo in aws_acm_certificate.awscommunity_certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.awscommunity_zone.zone_id
+}
+
+resource "aws_acm_certificate_validation" "awscommunity_certificate_validation" {
+  certificate_arn         = aws_acm_certificate.awscommunity_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.awscommunity_validation_record : record.fqdn]
+}


### PR DESCRIPTION
Closes #12

## Summary by Sourcery

Configure ACM certificate with Route53 DNS validation for the awscommunity.mx domain

New Features:
- Create a wildcard SSL certificate for *.app.awscommunity.mx using AWS ACM

Deployment:
- Set up DNS validation for the ACM certificate using Route53 records